### PR TITLE
Change function arguments to take T: ToString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- [#3](https://github.com/sunsided/query-string-builder/pull/3):
+  The functions now change inputs that implement `ToString` rather than requiring `Into<String>`.
+  This allows for any `Display` types to be used directly.
+
 ## [0.4.0] - 2023-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ use query_string_builder::QueryString;
 fn main() {
     let qs = QueryString::new()
         .with_value("q", "apple")
+        .with_value("tasty", true)
         .with_opt_value("color", None::<String>)
         .with_opt_value("category", Some("fruits and vegetables?"));
 
     assert_eq!(
         format!("https://example.com/{qs}"),
-        "https://example.com/?q=apple&category=fruits%20and%20vegetables?"
+        "https://example.com/?q=apple&tasty=true&category=fruits%20and%20vegetables?&tasty=true"
     );
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,12 +255,14 @@ mod tests {
     fn test_simple() {
         let qs = QueryString::new()
             .with_value("q", "apple???")
-            .with_value("category", "fruits and vegetables");
+            .with_value("category", "fruits and vegetables")
+            .with_value("tasty", true)
+            .with_value("weight", 99.9);
         assert_eq!(
             qs.to_string(),
-            "?q=apple???&category=fruits%20and%20vegetables"
+            "?q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
         );
-        assert_eq!(qs.len(), 2);
+        assert_eq!(qs.len(), 4);
         assert!(!qs.is_empty());
     }
 
@@ -268,12 +270,8 @@ mod tests {
     fn test_encoding() {
         let qs = QueryString::new()
             .with_value("q", "Grünkohl")
-            .with_value("category", "Gemüse")
-            .with_value("answer", 42);
-        assert_eq!(
-            qs.to_string(),
-            "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse&answer=42"
-        );
+            .with_value("category", "Gemüse");
+        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse");
     }
 
     #[test]
@@ -292,12 +290,14 @@ mod tests {
         let qs = QueryString::new()
             .with_value("q", "celery")
             .with_opt_value("taste", None::<String>)
-            .with_opt_value("category", Some("fruits and vegetables"));
+            .with_opt_value("category", Some("fruits and vegetables"))
+            .with_opt_value("tasty", Some(true))
+            .with_opt_value("weight", Some(99.9));
         assert_eq!(
             qs.to_string(),
-            "?q=celery&category=fruits%20and%20vegetables"
+            "?q=celery&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
         );
-        assert_eq!(qs.len(), 2); // not three!
+        assert_eq!(qs.len(), 4); // not five!
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,13 @@
 //!
 //! let qs = QueryString::new()
 //!             .with_value("q", "🍎 apple")
+//!             .with_value("tasty", true)
 //!             .with_opt_value("color", None::<String>)
 //!             .with_opt_value("category", Some("fruits and vegetables?"));
 //!
 //! assert_eq!(
 //!     format!("example.com/{qs}"),
-//!     "example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables?"
+//!     "example.com/?q=%F0%9F%8D%8E%20apple&tasty=true&category=fruits%20and%20vegetables?"
 //! );
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,17 +65,18 @@ impl QueryString {
     ///
     /// let qs = QueryString::new()
     ///             .with_value("q", "🍎 apple")
-    ///             .with_value("category", "fruits and vegetables");
+    ///             .with_value("category", "fruits and vegetables")
+    ///             .with_value("answer", 42);
     ///
     /// assert_eq!(
     ///     format!("https://example.com/{qs}"),
-    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables"
+    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&answer=42"
     /// );
     /// ```
-    pub fn with_value<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+    pub fn with_value<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
         self.pairs.push(Kvp {
-            key: key.into(),
-            value: value.into(),
+            key: key.to_string(),
+            value: value.to_string(),
         });
         self
     }
@@ -90,14 +91,15 @@ impl QueryString {
     /// let qs = QueryString::new()
     ///             .with_opt_value("q", Some("🍎 apple"))
     ///             .with_opt_value("f", None::<String>)
-    ///             .with_opt_value("category", Some("fruits and vegetables"));
+    ///             .with_opt_value("category", Some("fruits and vegetables"))
+    ///             .with_opt_value("works", Some(true));
     ///
     /// assert_eq!(
     ///     format!("https://example.com/{qs}"),
-    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables"
+    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&works=true"
     /// );
     /// ```
-    pub fn with_opt_value<K: Into<String>, V: Into<String>>(
+    pub fn with_opt_value<K: ToString, V: ToString>(
         self,
         key: K,
         value: Option<V>,
@@ -125,10 +127,10 @@ impl QueryString {
     ///     "https://example.com/?q=apple&category=fruits%20and%20vegetables"
     /// );
     /// ```
-    pub fn push<K: Into<String>, V: Into<String>>(&mut self, key: K, value: V) -> &Self {
+    pub fn push<K: ToString, V: ToString>(&mut self, key: K, value: V) -> &Self {
         self.pairs.push(Kvp {
-            key: key.into(),
-            value: value.into(),
+            key: key.to_string(),
+            value: value.to_string(),
         });
         self
     }
@@ -149,7 +151,7 @@ impl QueryString {
     ///     "https://example.com/?q=%F0%9F%8D%8E%20apple"
     /// );
     /// ```
-    pub fn push_opt<K: Into<String>, V: Into<String>>(
+    pub fn push_opt<K: ToString, V: ToString>(
         &mut self,
         key: K,
         value: Option<V>,
@@ -262,8 +264,9 @@ mod tests {
     fn test_encoding() {
         let qs = QueryString::new()
             .with_value("q", "Grünkohl")
-            .with_value("category", "Gemüse");
-        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse");
+            .with_value("category", "Gemüse")
+            .with_value("answer", 42);
+        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse&answer=42");
     }
 
     #[test]


### PR DESCRIPTION
Implements a solution for #2. With this (breaking) change, any displayable type can now be used directly:

```rust
let qs = QueryString::new()
            .with_value("q", "🍎 apple")
            .with_value("category", "fruits and vegetables")
            .with_value("weight", 42)
            .with_opt_value("tasty", Some(true));
```