### PR TITLE
Reduce number of `String` allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- [#3](https://github.com/sunsided/query-string-builder/pull/3):
+  The functions now change inputs that implement `ToString` rather than requiring `Into<String>`.
+  This allows for any `Display` types to be used directly.
+
 ## [0.4.0] - 2023-07-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ license = "EUPL-1.2"
 
 [dependencies]
 percent-encoding = { version = "2.3.0", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ use query_string_builder::QueryString;
 fn main() {
     let qs = QueryString::new()
         .with_value("q", "apple")
+        .with_value("tasty", true)
         .with_opt_value("color", None::<String>)
         .with_opt_value("category", Some("fruits and vegetables?"));
 
     assert_eq!(
         format!("https://example.com/{qs}"),
-        "https://example.com/?q=apple&category=fruits%20and%20vegetables?"
+        "https://example.com/?q=apple&tasty=true&category=fruits%20and%20vegetables?&tasty=true"
     );
 }
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use query_string_builder::QueryString;
 
@@ -9,6 +9,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let qs = QueryString::new()
                 .with_value("q", "apple???")
                 .with_value("category", "fruits and vegetables");
+            format!("{qs}")
+        })
+    });
+
+    c.bench_function("with_value_more", |b| {
+        b.iter(|| {
+            let qs = QueryString::new()
+                .with_value("q", "apple???")
+                .with_value("category", "fruits and vegetables")
+                .with_value("tasty", true)
+                .with_value("weight", 99.9);
             format!("{qs}")
         })
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,46 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use query_string_builder::QueryString;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // `with_value` method benchmark
+    c.bench_function("with_value", |b| {
+        b.iter(|| {
+            let qs = QueryString::new()
+                .with_value("q", "apple???")
+                .with_value("category", "fruits and vegetables");
+            format!("{qs}")
+        })
+    });
+
+    // `with_opt_value` method benchmark
+    c.bench_function("with_opt_value", |b| {
+        b.iter(|| {
+            let qs = QueryString::new()
+                .with_value("q", "celery")
+                .with_opt_value("taste", None::<String>)
+                .with_opt_value("category", Some("fruits and vegetables"))
+                .with_opt_value("tasty", Some(true))
+                .with_opt_value("weight", Some(99.9));
+            format!("{qs}")
+        })
+    });
+
+    // Full test including creating, pushing and appending
+    c.bench_function("push_opt_and_append", |b| {
+        b.iter(|| {
+            let mut qs = QueryString::new();
+            qs.push("a", "apple");
+            qs.push_opt("b", None::<String>);
+            qs.push_opt("c", Some("🍎 apple"));
+
+            let more = QueryString::new().with_value("q", "pear");
+            let qs = qs.append_into(more);
+
+            format!("{qs}")
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,14 +250,14 @@ impl<'a> Value<'a> {
     }
 }
 
-impl<'a> From<&'static str> for Key<'a> {
-    fn from(value: &'static str) -> Self {
+impl<'a> From<&'a str> for Key<'a> {
+    fn from(value: &'a str) -> Self {
         Self::from_str(value)
     }
 }
 
-impl<'a> From<&'static str> for Value<'a> {
-    fn from(value: &'static str) -> Self {
+impl<'a> From<&'a str> for Value<'a> {
+    fn from(value: &'a str) -> Self {
         Self::from_str(value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 
 use std::fmt::{Display, Formatter, Write};
 
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
@@ -254,40 +254,48 @@ pub struct Key<'a>(QueryPart<'a>);
 pub struct Value<'a>(QueryPart<'a>);
 
 impl<'a> Key<'a> {
+    #[inline(always)]
     pub fn from<T: ToString + 'static>(value: T) -> Self {
         Self(QueryPart::Owned(Box::new(value)))
     }
 
+    #[inline(always)]
     pub fn from_ref<T: ToString>(value: &'a T) -> Self {
         Self(QueryPart::Reference(value))
     }
 
+    #[inline(always)]
     pub fn from_str(key: &'a str) -> Key<'a> {
         Self(QueryPart::RefStr(key))
     }
 }
 
 impl<'a> Value<'a> {
+    #[inline(always)]
     pub fn from<T: ToString + 'static>(value: T) -> Self {
         Self(QueryPart::Owned(Box::new(value)))
     }
 
+    #[inline(always)]
     pub fn from_ref<T: ToString>(value: &'a T) -> Self {
         Self(QueryPart::Reference(value))
     }
 
+    #[inline(always)]
     pub fn from_str(value: &'a str) -> Self {
         Self(QueryPart::RefStr(&value))
     }
 }
 
 impl<'a> From<&'a str> for Key<'a> {
+    #[inline(always)]
     fn from(value: &'a str) -> Self {
         Self::from_str(value)
     }
 }
 
 impl<'a> From<&'a str> for Value<'a> {
+    #[inline(always)]
     fn from(value: &'a str) -> Self {
         Self::from_str(value)
     }
@@ -299,6 +307,7 @@ struct Kvp<'a> {
 }
 
 impl<'a> Kvp<'a> {
+    #[inline(always)]
     pub fn new<K: Into<QueryPart<'a>>, V: Into<QueryPart<'a>>>(key: K, value: V) -> Self {
         Self {
             key: key.into(),
@@ -315,12 +324,14 @@ enum QueryPart<'a> {
 }
 
 impl<'a> From<Key<'a>> for QueryPart<'a> {
+    #[inline(always)]
     fn from(value: Key<'a>) -> Self {
         value.0
     }
 }
 
 impl<'a> From<Value<'a>> for QueryPart<'a> {
+    #[inline(always)]
     fn from(value: Value<'a>) -> Self {
         value.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
@@ -309,9 +309,9 @@ impl Value {
     }
 
     pub fn lazy_fn<F, T>(func: F) -> Self
-        where
-            F: Fn() -> T + 'static,
-            T: ToString + 'static,
+    where
+        F: Fn() -> T + 'static,
+        T: ToString + 'static,
     {
         Value {
             value: Box::new(move || func().to_string()),
@@ -324,8 +324,8 @@ impl Value {
 }
 
 impl<T> From<Rc<T>> for Value
-    where
-        T: ToString + 'static,
+where
+    T: ToString + 'static,
 {
     fn from(value: Rc<T>) -> Self {
         Value::lazy_rc(value)
@@ -333,8 +333,8 @@ impl<T> From<Rc<T>> for Value
 }
 
 impl<T> From<Arc<T>> for Value
-    where
-        T: ToString + 'static,
+where
+    T: ToString + 'static,
 {
     fn from(value: Arc<T>) -> Self {
         Value::lazy_arc(value)
@@ -342,9 +342,9 @@ impl<T> From<Arc<T>> for Value
 }
 
 impl<F, T> From<F> for Value
-    where
-        F: Fn() -> T + 'static,
-        T: ToString + 'static,
+where
+    F: Fn() -> T + 'static,
+    T: ToString + 'static,
 {
     fn from(value: F) -> Self {
         Value::lazy_fn(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,12 @@
 
 #![deny(unsafe_code)]
 
-use std::fmt::{Display, Formatter};
-use std::rc::Rc;
-use std::sync::Arc;
+use std::fmt::{Display, Formatter, Write};
 
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
-const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
 
 /// A query string builder for percent encoding key-value pairs.
 ///
@@ -48,11 +46,11 @@ const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').ad
 /// );
 /// ```
 #[derive(Default)]
-pub struct QueryString {
-    pairs: Vec<Kvp>,
+pub struct QueryString<'a> {
+    pairs: Vec<Kvp<'a>>,
 }
 
-impl QueryString {
+impl<'a> QueryString<'a> {
     /// Creates a new, empty query string builder.
     pub fn new() -> Self {
         Self {
@@ -77,37 +75,8 @@ impl QueryString {
     ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&answer=42"
     /// );
     /// ```
-    pub fn with_value<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
-        self.pairs.push(Kvp {
-            key: key.to_string(),
-            value: Value::eager(value),
-        });
-        self
-    }
-
-    /// Appends a key-value pair to the query string. Supports lazy evaluation.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use std::sync::Arc;
-    /// use query_string_builder::{QueryString, Value};
-    ///
-    /// let qs = QueryString::new()
-    ///             .with("q", Value::eager("🍎 apple"))
-    ///             .with("category", || "fruits and vegetables")
-    ///             .with("answer", Arc::new(42));
-    ///
-    /// assert_eq!(
-    ///     format!("https://example.com/{qs}"),
-    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&answer=42"
-    /// );
-    /// ```
-    pub fn with<K: ToString, V: Into<Value>>(mut self, key: K, value: V) -> Self {
-        self.pairs.push(Kvp {
-            key: key.to_string(),
-            value: value.into(),
-        });
+    pub fn with_value<K: ToString + 'static, V: ToString + 'static>(mut self, key: K, value: V) -> Self {
+        self.pairs.push(Kvp::new(QueryPart::from_tostring(key), QueryPart::from_tostring(value)));
         self
     }
 
@@ -129,7 +98,7 @@ impl QueryString {
     ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&works=true"
     /// );
     /// ```
-    pub fn with_opt_value<K: ToString, V: ToString>(self, key: K, value: Option<V>) -> Self {
+    pub fn with_opt_value<K: ToString + 'static, V: ToString + 'static>(self, key: K, value: Option<V>) -> Self {
         if let Some(value) = value {
             self.with_value(key, value)
         } else {
@@ -153,11 +122,8 @@ impl QueryString {
     ///     "https://example.com/?q=apple&category=fruits%20and%20vegetables"
     /// );
     /// ```
-    pub fn push<K: ToString, V: ToString>(&mut self, key: K, value: V) -> &Self {
-        self.pairs.push(Kvp {
-            key: key.to_string(),
-            value: Value::eager(value),
-        });
+    pub fn push<K: ToString + 'static, V: ToString + 'static>(&mut self, key: K, value: V) -> &Self {
+        self.pairs.push(Kvp::new(QueryPart::from_tostring(key), QueryPart::from_tostring(value)));
         self
     }
 
@@ -177,7 +143,7 @@ impl QueryString {
     ///     "https://example.com/?q=%F0%9F%8D%8E%20apple"
     /// );
     /// ```
-    pub fn push_opt<K: ToString, V: ToString>(&mut self, key: K, value: Option<V>) -> &Self {
+    pub fn push_opt<K: ToString + 'static, V: ToString + 'static>(&mut self, key: K, value: Option<V>) -> &Self {
         if let Some(value) = value {
             self.push(key, value)
         } else {
@@ -212,7 +178,7 @@ impl QueryString {
     ///     "https://example.com/?q=apple&q=pear"
     /// );
     /// ```
-    pub fn append(&mut self, mut other: QueryString) {
+    pub fn append(&mut self, mut other: QueryString<'a>) {
         self.pairs.append(&mut other.pairs)
     }
 
@@ -233,121 +199,66 @@ impl QueryString {
     ///     "https://example.com/?q=apple&q=pear"
     /// );
     /// ```
-    pub fn append_into(mut self, mut other: QueryString) -> Self {
+    pub fn append_into(mut self, mut other: QueryString<'a>) -> Self {
         self.pairs.append(&mut other.pairs);
         self
     }
 }
 
-impl Display for QueryString {
+impl<'a> Display for QueryString<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if self.pairs.is_empty() {
             Ok(())
         } else {
-            write!(f, "?")?;
+            f.write_char('?')?;
             for (i, pair) in self.pairs.iter().enumerate() {
                 if i > 0 {
-                    write!(f, "&")?;
+                    f.write_char('&')?;
                 }
 
-                // We convert the value to a String here. Ideally we'd print it directly (skipping
-                // the intermediate string generation) but due to the required percent encoding
-                // this isn't immediately possible.
-                let value = pair.value.render();
-
-                write!(
-                    f,
-                    "{key}={value}",
-                    key = utf8_percent_encode(&pair.key, FRAGMENT),
-                    value = utf8_percent_encode(&value, FRAGMENT)
-                )?;
+                Display::fmt(&utf8_percent_encode(&pair.key.to_string(), QUERY), f)?;
+                f.write_char('=')?;
+                Display::fmt(&utf8_percent_encode(&pair.value.to_string(), QUERY), f)?;
             }
             Ok(())
         }
     }
 }
 
-struct Kvp {
-    key: String,
-    value: Value,
+pub struct Key<'a>(QueryPart<'a>);
+
+pub struct Value<'a>(QueryPart<'a>);
+
+struct Kvp<'a> {
+    key: QueryPart<'a>,
+    value: QueryPart<'a>,
 }
 
-pub struct Value {
-    value: Box<dyn Fn() -> String>,
-}
-
-impl Value {
-    pub fn eager<T: ToString>(value: T) -> Self {
-        let value = value.to_string();
-        Value {
-            value: Box::new(move || value.to_string()),
-        }
-    }
-
-    pub fn lazy<T: ToString + 'static>(value: T) -> Self {
-        Value {
-            value: Box::new(move || value.to_string()),
-        }
-    }
-
-    pub fn lazy_box<T: ToString + 'static>(value: Box<T>) -> Self {
-        Value {
-            value: Box::new(move || value.to_string()),
-        }
-    }
-
-    pub fn lazy_rc<T: ToString + 'static>(value: Rc<T>) -> Self {
-        Value {
-            value: Box::new(move || value.to_string()),
-        }
-    }
-
-    pub fn lazy_arc<T: ToString + 'static>(value: Arc<T>) -> Self {
-        Value {
-            value: Box::new(move || value.to_string()),
-        }
-    }
-
-    pub fn lazy_fn<F, T>(func: F) -> Self
-    where
-        F: Fn() -> T + 'static,
-        T: ToString + 'static,
-    {
-        Value {
-            value: Box::new(move || func().to_string()),
-        }
-    }
-
-    fn render(&self) -> String {
-        (self.value)()
+impl<'a> Kvp<'a> {
+    pub fn new<K: Into<QueryPart<'a>>, V: Into<QueryPart<'a>>>(key: K, value: V) -> Self {
+        Self { key: key.into(), value: value.into() }
     }
 }
 
-impl<T> From<Rc<T>> for Value
-where
-    T: ToString + 'static,
-{
-    fn from(value: Rc<T>) -> Self {
-        Value::lazy_rc(value)
+enum QueryPart<'a> {
+    Owned(Box<dyn ToString>),
+    Reference(&'a dyn ToString),
+    Boxed(Box<dyn Fn(&mut Formatter) -> std::fmt::Result>),
+}
+
+impl<'a> QueryPart<'a> {
+    pub fn from_tostring<T: ToString + 'static>(text: T) -> Self {
+        Self::Owned(Box::new(text))
     }
 }
 
-impl<T> From<Arc<T>> for Value
-where
-    T: ToString + 'static,
-{
-    fn from(value: Arc<T>) -> Self {
-        Value::lazy_arc(value)
-    }
-}
-
-impl<F, T> From<F> for Value
-where
-    F: Fn() -> T + 'static,
-    T: ToString + 'static,
-{
-    fn from(value: F) -> Self {
-        Value::lazy_fn(value)
+impl<'a> Display for QueryPart<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryPart::Owned(b) => f.write_str(&b.to_string()),
+            QueryPart::Reference(b) => f.write_str(&b.to_string()),
+            QueryPart::Boxed(b) => b(f),
+        }
     }
 }
 
@@ -376,33 +287,6 @@ mod tests {
         );
         assert_eq!(qs.len(), 4);
         assert!(!qs.is_empty());
-    }
-
-    #[test]
-    fn test_lazy() {
-        let qs = QueryString::new()
-            .with("x", Value::eager("y"))
-            .with("q", Value::lazy("apple???"))
-            .with("category", Value::lazy_fn(|| "fruits and vegetables"))
-            .with("tasty", Value::lazy_box(Box::new(true)))
-            .with("weight", Value::lazy_arc(Arc::new(99.9)));
-        assert_eq!(
-            qs.to_string(),
-            "?x=y&q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
-        );
-    }
-
-    #[test]
-    fn test_lazy_implicit() {
-        let qs = QueryString::new()
-            .with("q", Value::lazy("apple???"))
-            .with("category", || "fruits and vegetables")
-            .with("tasty", Rc::new(true))
-            .with("weight", Arc::new(99.9));
-        assert_eq!(
-            qs.to_string(),
-            "?q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
-        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,12 +255,14 @@ mod tests {
     fn test_simple() {
         let qs = QueryString::new()
             .with_value("q", "apple???")
-            .with_value("category", "fruits and vegetables");
+            .with_value("category", "fruits and vegetables")
+            .with_value("tasty", true)
+            .with_value("weight", 99.9);
         assert_eq!(
             qs.to_string(),
-            "?q=apple???&category=fruits%20and%20vegetables"
+            "?q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
         );
-        assert_eq!(qs.len(), 2);
+        assert_eq!(qs.len(), 4);
         assert!(!qs.is_empty());
     }
 
@@ -268,12 +270,8 @@ mod tests {
     fn test_encoding() {
         let qs = QueryString::new()
             .with_value("q", "Grünkohl")
-            .with_value("category", "Gemüse")
-            .with_value("answer", 42);
-        assert_eq!(
-            qs.to_string(),
-            "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse&answer=42"
-        );
+            .with_value("category", "Gemüse");
+        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse");
     }
 
     #[test]
@@ -292,12 +290,14 @@ mod tests {
         let qs = QueryString::new()
             .with_value("q", "celery")
             .with_opt_value("taste", None::<String>)
-            .with_opt_value("category", Some("fruits and vegetables"));
+            .with_opt_value("category", Some("fruits and vegetables"))
+            .with_opt_value("tasty", Some(true))
+            .with_opt_value("weight", Some(99.9));
         assert_eq!(
             qs.to_string(),
-            "?q=celery&category=fruits%20and%20vegetables"
+            "?q=celery&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
         );
-        assert_eq!(qs.len(), 2); // not three!
+        assert_eq!(qs.len(), 4); // not five!
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,13 @@
 //!
 //! let qs = QueryString::new()
 //!             .with_value("q", "🍎 apple")
+//!             .with_value("tasty", true)
 //!             .with_opt_value("color", None::<String>)
 //!             .with_opt_value("category", Some("fruits and vegetables?"));
 //!
 //! assert_eq!(
 //!     format!("example.com/{qs}"),
-//!     "example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables?"
+//!     "example.com/?q=%F0%9F%8D%8E%20apple&tasty=true&category=fruits%20and%20vegetables?"
 //! );
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,17 +65,18 @@ impl QueryString {
     ///
     /// let qs = QueryString::new()
     ///             .with_value("q", "🍎 apple")
-    ///             .with_value("category", "fruits and vegetables");
+    ///             .with_value("category", "fruits and vegetables")
+    ///             .with_value("answer", 42);
     ///
     /// assert_eq!(
     ///     format!("https://example.com/{qs}"),
-    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables"
+    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&answer=42"
     /// );
     /// ```
-    pub fn with_value<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+    pub fn with_value<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
         self.pairs.push(Kvp {
-            key: key.into(),
-            value: value.into(),
+            key: key.to_string(),
+            value: value.to_string(),
         });
         self
     }
@@ -90,14 +91,15 @@ impl QueryString {
     /// let qs = QueryString::new()
     ///             .with_opt_value("q", Some("🍎 apple"))
     ///             .with_opt_value("f", None::<String>)
-    ///             .with_opt_value("category", Some("fruits and vegetables"));
+    ///             .with_opt_value("category", Some("fruits and vegetables"))
+    ///             .with_opt_value("works", Some(true));
     ///
     /// assert_eq!(
     ///     format!("https://example.com/{qs}"),
-    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables"
+    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&works=true"
     /// );
     /// ```
-    pub fn with_opt_value<K: Into<String>, V: Into<String>>(
+    pub fn with_opt_value<K: ToString, V: ToString>(
         self,
         key: K,
         value: Option<V>,
@@ -125,10 +127,10 @@ impl QueryString {
     ///     "https://example.com/?q=apple&category=fruits%20and%20vegetables"
     /// );
     /// ```
-    pub fn push<K: Into<String>, V: Into<String>>(&mut self, key: K, value: V) -> &Self {
+    pub fn push<K: ToString, V: ToString>(&mut self, key: K, value: V) -> &Self {
         self.pairs.push(Kvp {
-            key: key.into(),
-            value: value.into(),
+            key: key.to_string(),
+            value: value.to_string(),
         });
         self
     }
@@ -149,7 +151,7 @@ impl QueryString {
     ///     "https://example.com/?q=%F0%9F%8D%8E%20apple"
     /// );
     /// ```
-    pub fn push_opt<K: Into<String>, V: Into<String>>(
+    pub fn push_opt<K: ToString, V: ToString>(
         &mut self,
         key: K,
         value: Option<V>,
@@ -262,8 +264,9 @@ mod tests {
     fn test_encoding() {
         let qs = QueryString::new()
             .with_value("q", "Grünkohl")
-            .with_value("category", "Gemüse");
-        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse");
+            .with_value("category", "Gemüse")
+            .with_value("answer", 42);
+        assert_eq!(qs.to_string(), "?q=Gr%C3%BCnkohl&category=Gem%C3%BCse&answer=42");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,14 +339,17 @@ impl<'a> From<Value<'a>> for QueryPart<'a> {
 
 impl<'a> Display for QueryPart<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let encode = |x| utf8_percent_encode(x, QUERY);
-        let mut write = |x| Display::fmt(&encode(x), f);
         match self {
-            QueryPart::Owned(b) => write(&b.to_string()),
-            QueryPart::Reference(b) => write(&b.to_string()),
-            QueryPart::RefStr(s) => write(s),
+            QueryPart::Owned(b) => write(&b.to_string(), f),
+            QueryPart::Reference(b) => write(&b.to_string(), f),
+            QueryPart::RefStr(s) => write(s, f),
         }
     }
+}
+
+#[inline(always)]
+fn write(x: &str, f: &mut Formatter<'_>) -> std::fmt::Result {
+    Display::fmt(&utf8_percent_encode(x, QUERY), f)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
@@ -250,7 +250,11 @@ impl Display for QueryString {
                     write!(f, "&")?;
                 }
 
+                // We convert the value to a String here. Ideally we'd print it directly (skipping
+                // the intermediate string generation) but due to the required percent encoding
+                // this isn't immediately possible.
                 let value = pair.value.render();
+
                 write!(
                     f,
                     "{key}={value}",
@@ -305,9 +309,9 @@ impl Value {
     }
 
     pub fn lazy_fn<F, T>(func: F) -> Self
-    where
-        F: Fn() -> T + 'static,
-        T: ToString + 'static,
+        where
+            F: Fn() -> T + 'static,
+            T: ToString + 'static,
     {
         Value {
             value: Box::new(move || func().to_string()),
@@ -320,8 +324,8 @@ impl Value {
 }
 
 impl<T> From<Rc<T>> for Value
-where
-    T: ToString + 'static,
+    where
+        T: ToString + 'static,
 {
     fn from(value: Rc<T>) -> Self {
         Value::lazy_rc(value)
@@ -329,8 +333,8 @@ where
 }
 
 impl<T> From<Arc<T>> for Value
-where
-    T: ToString + 'static,
+    where
+        T: ToString + 'static,
 {
     fn from(value: Arc<T>) -> Self {
         Value::lazy_arc(value)
@@ -338,9 +342,9 @@ where
 }
 
 impl<F, T> From<F> for Value
-where
-    F: Fn() -> T + 'static,
-    T: ToString + 'static,
+    where
+        F: Fn() -> T + 'static,
+        T: ToString + 'static,
 {
     fn from(value: F) -> Self {
         Value::lazy_fn(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@
 
 #![deny(unsafe_code)]
 
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Display, Formatter};
+use std::rc::Rc;
+use std::sync::Arc;
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
@@ -45,7 +47,7 @@ const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').ad
 ///     "https://example.com/?q=apple&category=fruits%20and%20vegetables"
 /// );
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Default)]
 pub struct QueryString {
     pairs: Vec<Kvp>,
 }
@@ -78,7 +80,33 @@ impl QueryString {
     pub fn with_value<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
         self.pairs.push(Kvp {
             key: key.to_string(),
-            value: value.to_string(),
+            value: Value::eager(value),
+        });
+        self
+    }
+
+    /// Appends a key-value pair to the query string. Supports lazy evaluation.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use query_string_builder::{QueryString, Value};
+    ///
+    /// let qs = QueryString::new()
+    ///             .with("q", Value::eager("🍎 apple"))
+    ///             .with("category", || "fruits and vegetables")
+    ///             .with("answer", Arc::new(42));
+    ///
+    /// assert_eq!(
+    ///     format!("https://example.com/{qs}"),
+    ///     "https://example.com/?q=%F0%9F%8D%8E%20apple&category=fruits%20and%20vegetables&answer=42"
+    /// );
+    /// ```
+    pub fn with<K: ToString, V: Into<Value>>(mut self, key: K, value: V) -> Self {
+        self.pairs.push(Kvp {
+            key: key.to_string(),
+            value: value.into(),
         });
         self
     }
@@ -128,7 +156,7 @@ impl QueryString {
     pub fn push<K: ToString, V: ToString>(&mut self, key: K, value: V) -> &Self {
         self.pairs.push(Kvp {
             key: key.to_string(),
-            value: value.to_string(),
+            value: Value::eager(value),
         });
         self
     }
@@ -221,11 +249,13 @@ impl Display for QueryString {
                 if i > 0 {
                     write!(f, "&")?;
                 }
+
+                let value = pair.value.render();
                 write!(
                     f,
                     "{key}={value}",
                     key = utf8_percent_encode(&pair.key, FRAGMENT),
-                    value = utf8_percent_encode(&pair.value, FRAGMENT)
+                    value = utf8_percent_encode(&value, FRAGMENT)
                 )?;
             }
             Ok(())
@@ -233,10 +263,88 @@ impl Display for QueryString {
     }
 }
 
-#[derive(Debug, Clone)]
 struct Kvp {
     key: String,
-    value: String,
+    value: Value,
+}
+
+pub struct Value {
+    value: Box<dyn Fn() -> String>,
+}
+
+impl Value {
+    pub fn eager<T: ToString>(value: T) -> Self {
+        let value = value.to_string();
+        Value {
+            value: Box::new(move || value.to_string()),
+        }
+    }
+
+    pub fn lazy<T: ToString + 'static>(value: T) -> Self {
+        Value {
+            value: Box::new(move || value.to_string()),
+        }
+    }
+
+    pub fn lazy_box<T: ToString + 'static>(value: Box<T>) -> Self {
+        Value {
+            value: Box::new(move || value.to_string()),
+        }
+    }
+
+    pub fn lazy_rc<T: ToString + 'static>(value: Rc<T>) -> Self {
+        Value {
+            value: Box::new(move || value.to_string()),
+        }
+    }
+
+    pub fn lazy_arc<T: ToString + 'static>(value: Arc<T>) -> Self {
+        Value {
+            value: Box::new(move || value.to_string()),
+        }
+    }
+
+    pub fn lazy_fn<F, T>(func: F) -> Self
+    where
+        F: Fn() -> T + 'static,
+        T: ToString + 'static,
+    {
+        Value {
+            value: Box::new(move || func().to_string()),
+        }
+    }
+
+    fn render(&self) -> String {
+        (self.value)()
+    }
+}
+
+impl<T> From<Rc<T>> for Value
+where
+    T: ToString + 'static,
+{
+    fn from(value: Rc<T>) -> Self {
+        Value::lazy_rc(value)
+    }
+}
+
+impl<T> From<Arc<T>> for Value
+where
+    T: ToString + 'static,
+{
+    fn from(value: Arc<T>) -> Self {
+        Value::lazy_arc(value)
+    }
+}
+
+impl<F, T> From<F> for Value
+where
+    F: Fn() -> T + 'static,
+    T: ToString + 'static,
+{
+    fn from(value: F) -> Self {
+        Value::lazy_fn(value)
+    }
 }
 
 #[cfg(test)]
@@ -264,6 +372,33 @@ mod tests {
         );
         assert_eq!(qs.len(), 4);
         assert!(!qs.is_empty());
+    }
+
+    #[test]
+    fn test_lazy() {
+        let qs = QueryString::new()
+            .with("x", Value::eager("y"))
+            .with("q", Value::lazy("apple???"))
+            .with("category", Value::lazy_fn(|| "fruits and vegetables"))
+            .with("tasty", Value::lazy_box(Box::new(true)))
+            .with("weight", Value::lazy_arc(Arc::new(99.9)));
+        assert_eq!(
+            qs.to_string(),
+            "?x=y&q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
+        );
+    }
+
+    #[test]
+    fn test_lazy_implicit() {
+        let qs = QueryString::new()
+            .with("q", Value::lazy("apple???"))
+            .with("category", || "fruits and vegetables")
+            .with("tasty", Rc::new(true))
+            .with("weight", Arc::new(99.9));
+        assert_eq!(
+            qs.to_string(),
+            "?q=apple???&category=fruits%20and%20vegetables&tasty=true&weight=99.9"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements a possible solution for #5. Builds upon #3 for the `ToString` support. The lazy evaluation allows to defer the `to_string()` call until the rendering actually takes place.