### PR TITLE
Add test for character encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - More characters are added to the encoding set to ensure recursive values
   (e.g. URLs as a value) decode reliably.
 
+### Fixed
+
+- The hash character `#` is now encoded in order to ensure correct parsing of query parameters.
+
 ## [0.4.0] - 2023-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- More characters are added to the encoding set to ensure recursive values
+  (e.g. URLs as a value) decode reliably.
+
 ## [0.4.0] - 2023-07-08
 
 ### Added
@@ -29,5 +36,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - 🎉 Initial release.
 
 [0.3.0]: https://github.com/sunsided/query-string-builder/releases/tag/0.3.0
+
 [0.2.0]: https://github.com/sunsided/query-string-builder/releases/tag/0.2.0
+
 [0.1.0]: https://github.com/sunsided/query-string-builder/releases/tag/0.1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,16 +23,24 @@
 
 use std::fmt::{Debug, Display, Formatter};
 
-use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
 /// https://url.spec.whatwg.org/#query-percent-encode-set
-const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>')
+const QUERY: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
     // The following values are not strictly required by RFC 3986 but could help resolving recursion
     // where a URL is passed as a value. In these cases, occurrences of equal signs and ampersands
     // could break parsing.
     // By a similar logic, encoding the percent sign helps to resolve ambiguity.
     // The plus sign is also added to the set as to not confuse it with a space.
-    .add(b'%').add(b'&').add(b'=').add(b'+');
+    .add(b'%')
+    .add(b'&')
+    .add(b'=')
+    .add(b'+');
 
 /// A query string builder for percent encoding key-value pairs.
 ///
@@ -381,6 +389,7 @@ mod tests {
 
         assert_eq!(
             format!("https://example.com/{qs}"),
-            format!("https://example.com/?{expected}"));
+            format!("https://example.com/?{expected}")
+        );
     }
 }


### PR DESCRIPTION
This adds test cases for character encodings and ensures that in addition to the RFC 3986 mandated characters, the following values are percent encoded as well: `#`, `%`, `&`, `=`, and `+`.