### PR TITLE
Replace write! with write_char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Internal
+
+- `write_char()` and `fmt()` calls are now used instead of `write!` when rendering the string.
+
 ## [0.5.0] - 2024-05-24
 
 [0.5.0]: https://github.com/sunsided/query-string-builder/releases/tag/v0.5.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![deny(unsafe_code)]
 
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Display, Formatter, Write};
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
@@ -230,17 +230,15 @@ impl Display for QueryString {
         if self.pairs.is_empty() {
             Ok(())
         } else {
-            write!(f, "?")?;
+            f.write_char('?')?;
             for (i, pair) in self.pairs.iter().enumerate() {
                 if i > 0 {
-                    write!(f, "&")?;
+                    f.write_char('&')?;
                 }
-                write!(
-                    f,
-                    "{key}={value}",
-                    key = utf8_percent_encode(&pair.key, QUERY),
-                    value = utf8_percent_encode(&pair.value, QUERY)
-                )?;
+
+                utf8_percent_encode(&pair.key, QUERY).fmt(f)?;
+                f.write_char('=')?;
+                utf8_percent_encode(&pair.value, QUERY).fmt(f)?;
             }
             Ok(())
         }


### PR DESCRIPTION
This replaces use of `write!(f, "{}", ...)` with calls to `write_char` where possible.